### PR TITLE
upgrade to ember-cli@2.12, support 2.13+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# v0.2.0
+#### 2017-08-03
+
+- upgrades ember-cli to 2.12.2, so the addon works on ember-cli@2.13+
+- cleaned up / removed some unnecessary dependencies
+- added a changelog, finally

--- a/bower.json
+++ b/bower.json
@@ -2,15 +2,6 @@
   "name": "ember-cli-highcharts",
   "dependencies": {
     "jquery": "^1.11.1",
-    "ember": "1.11.0",
-    "ember-data": "1.0.0-beta.16.1",
-    "ember-resolver": "~0.1.15",
-    "loader.js": "ember-cli/loader.js#3.2.0",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "0.3.0",
-    "ember-qunit-notifications": "0.0.7",
-    "qunit": "~1.17.1"
+    "ember": "1.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-highcharts",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",
@@ -22,26 +22,31 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
-    "ember-cli": "0.2.2",
-    "ember-cli-app-version": "0.3.3",
-    "ember-cli-content-security-policy": "0.4.0",
-    "ember-cli-dependency-checker": "0.0.8",
-    "ember-cli-htmlbars": "0.7.4",
-    "ember-cli-ic-ajax": "0.1.1",
+    "ember-cli": "2.12.3",
+    "ember-cli-app-version": "^3.0.0",
+    "ember-cli-content-security-policy": "^0.6.1",
+    "ember-cli-dependency-checker": "^1.4.0",
+    "ember-cli-htmlbars": "^1.3.0",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.0",
+    "ember-cli-ic-ajax": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.9",
-    "ember-cli-uglify": "1.0.1",
-    "ember-data": "1.0.0-beta.16.1",
-    "ember-export-application-global": "^1.0.2",
-    "ember-disable-prototype-extensions": "^1.0.0"
+    "ember-cli-qunit": "3.1.2",
+    "ember-cli-shims": "^1.0.2",
+    "ember-cli-sri": "^2.1.0",
+    "ember-cli-uglify": "^1.2.0",
+    "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-export-application-global": "^2.0.0",
+    "ember-load-initializers": "^0.6.0",
+    "ember-resolver": "^2.0.3",
+    "loader.js": "^4.2.3"
   },
   "keywords": [
     "ember-addon",
-	"ember-cli-highcharts",
-	"highcharts"
+    "ember-cli-highcharts",
+    "highcharts"
   ],
   "dependencies": {
-    "ember-cli-babel": "^4.0.0"
+    "ember-cli-babel": "^6.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
# v0.2.0
#### 2017-08-03

- upgrades ember-cli to 2.12.2, so the addon works on ember-cli@2.13+
- cleaned up / removed some unnecessary dependencies
- added a changelog, finally